### PR TITLE
Correction notice WP_Widget constructor avec PHP7

### DIFF
--- a/formulaires/etiquettes/etiquettes.php
+++ b/formulaires/etiquettes/etiquettes.php
@@ -474,7 +474,7 @@ class GTags_Widget extends WP_Widget {
 	function GTags_Widget() {
 		$widget_ops = array( 'classname' => 'gtags', 'description' => 'Show a tag cloud for Group Tags' );
 		$control_ops = array( 'id_base' => 'gtags-widget' );
-		$this->WP_Widget( 'gtags-widget', 'Group Tags', $widget_ops, $control_ops );
+		parent::__construct( 'gtags-widget', 'Group Tags', $widget_ops, $control_ops );
 	}
 
 	function widget( $args, $instance ) {
@@ -734,7 +734,7 @@ class GTags_Activity_Widget extends WP_Widget {
 	function GTags_Activity_Widget() {
 		$widget_ops = array( 'classname' => 'gtags_activity', 'description' => 'Show a activity for all groups matching a tag.' );
 		$control_ops = array( 'id_base' => 'gtags-activity-widget' );
-		$this->WP_Widget( 'gtags-activity-widget', 'Group Tags Activity', $widget_ops, $control_ops );
+		parent::__construct( 'gtags-activity-widget', 'Group Tags Activity', $widget_ops, $control_ops );
 	}
 	
 	function widget( $args, $instance ) {


### PR DESCRIPTION
Pour faire disparaitre les notices suivantes :

> Notice: La méthode du constructeur appelée pour WP_Widget dans GTags_Widget est obsolète depuis la version 4.3.0 ! Utilisez __construct() à la place. in /srv/www/wordpress-default/wp-includes/functions.php on line 3767
> Notice: La méthode du constructeur appelée pour WP_Widget dans GTags_Activity_Widget est obsolète depuis la version 4.3.0 ! Utilisez __construct() à la place. in /srv/www/wordpress-default/wp-includes/functions.php on line 3767

Pourquoi ?

> PHP7 is slated for release later this year. One of the changes is that PHP4 style constructors are deprecated. In order to prepare WordPress to support PHP7, these constructors have been deprecated in WordPress core. 

[source](https://codex.wordpress.org/Version_4.3)